### PR TITLE
Implement case categorization logic with classifier integration

### DIFF
--- a/backend/agent_with_tools/tools/categorize_case.py
+++ b/backend/agent_with_tools/tools/categorize_case.py
@@ -1,5 +1,7 @@
 """Case categorization tool."""
 
+import os
+import logging
 from backend.agent_with_tools.schemas import CategoryResult
 from classifier.classifier_chain import get_classifier_chain
 
@@ -21,7 +23,6 @@ def categorize_case(text: str) -> CategoryResult:
     """
     try:
         # Set the API key in the environment for the classifier
-        import os
         if "APERTUS_API_KEY" in os.environ and "API_KEY" not in os.environ:
             os.environ["API_KEY"] = os.environ["APERTUS_API_KEY"]
         
@@ -56,5 +57,5 @@ def categorize_case(text: str) -> CategoryResult:
         
     except Exception as e:
         # Fallback in case of classifier failure
-        print(f"Classifier failed: {e}, falling back to 'Andere'")
+        logging.error(f"Classifier failed: {e}, falling back to 'Andere'")
         return CategoryResult(category="Andere", confidence=0.50)

--- a/backend/agent_with_tools/tools/categorize_case.py
+++ b/backend/agent_with_tools/tools/categorize_case.py
@@ -1,11 +1,12 @@
 """Case categorization tool."""
 
 from backend.agent_with_tools.schemas import CategoryResult
+from classifier.classifier_chain import get_classifier_chain
 
 
 def categorize_case(text: str) -> CategoryResult:
     """
-    Categorize a legal case into one of four categories.
+    Categorize a legal case into one of three categories.
     
     Args:
         text: Case description text to categorize
@@ -14,7 +15,46 @@ def categorize_case(text: str) -> CategoryResult:
         CategoryResult with category and confidence score
         
     Note:
-        This is a stub implementation. Real implementation will use
-        ML model or business logic for classification.
+        Uses the actual classifier chain that returns traffic_law and employment_law booleans.
+        Maps to: Arbeitsrecht (employment_law=True), Strafverkehrsrecht (traffic_law=True), 
+        Andere (both False or ambiguous cases).
     """
-    raise NotImplementedError("Case categorization not yet implemented")
+    try:
+        # Set the API key in the environment for the classifier
+        import os
+        if "APERTUS_API_KEY" in os.environ and "API_KEY" not in os.environ:
+            os.environ["API_KEY"] = os.environ["APERTUS_API_KEY"]
+        
+        # Get the classifier chain
+        classifier = get_classifier_chain()
+        
+        # Run classification with empty chat history
+        result = classifier.invoke({"user_input": text, "chat_history": []})
+        
+        # Map classifier output to our schema
+        traffic_law = result.get("traffic_law", False)
+        employment_law = result.get("employment_law", False)
+        
+        # Determine category based on the boolean flags
+        if employment_law and not traffic_law:
+            category = "Arbeitsrecht"
+            confidence = 0.85  # High confidence for single match
+        elif traffic_law and not employment_law:
+            category = "Strafverkehrsrecht" 
+            confidence = 0.85  # High confidence for single match
+        elif employment_law and traffic_law:
+            # Both categories match - choose the more likely one or default to Andere
+            # For now, we'll default to Andere for ambiguous cases
+            category = "Andere"
+            confidence = 0.60  # Lower confidence for ambiguous cases
+        else:
+            # Neither category matches
+            category = "Andere"
+            confidence = 0.70  # Medium confidence for clear non-match
+            
+        return CategoryResult(category=category, confidence=confidence)
+        
+    except Exception as e:
+        # Fallback in case of classifier failure
+        print(f"Classifier failed: {e}, falling back to 'Andere'")
+        return CategoryResult(category="Andere", confidence=0.50)

--- a/classifier/classifier_chain.py
+++ b/classifier/classifier_chain.py
@@ -3,7 +3,7 @@ import os
 from langchain_core.prompts import PromptTemplate
 from langchain_core.output_parsers.json import JsonOutputParser
 
-from apertus import LangchainApertus
+from apertus.apertus import LangchainApertus
 
 
 def get_classifier_chain():


### PR DESCRIPTION
This pull request updates the case categorization tool to use a real classifier chain for determining legal case categories, replacing the previous stub implementation. The main focus is on integrating the actual classifier logic and mapping its output to the application's schema, with improved error handling and confidence scoring.

**Case Categorization Improvements:**

* Replaced the stub implementation in `categorize_case` with logic that uses the `get_classifier_chain` function to classify input text into one of three categories: "Arbeitsrecht", "Strafverkehrsrecht", or "Andere", based on boolean flags returned by the classifier. Added confidence scores and improved error handling for fallback scenarios. [[1]](diffhunk://#diff-bc4a250414b9b4b87d06d0f04e0ec10b8e8d16d6f1133e7155a4f8914451fa4eR4-R9) [[2]](diffhunk://#diff-bc4a250414b9b4b87d06d0f04e0ec10b8e8d16d6f1133e7155a4f8914451fa4eL17-R60)

**Dependency Update:**

* Updated the import in `classifier/classifier_chain.py` to use `from apertus.apertus import LangchainApertus` for correct module referencing.